### PR TITLE
Use error class in tests

### DIFF
--- a/tests/testthat/test-private_server.R
+++ b/tests/testthat/test-private_server.R
@@ -23,15 +23,15 @@ RANDOM_STRING <- jsonlite::base64url_enc(paste0("private", as.character(Sys.time
 test_that("no auth and bad auth fail", {
   skip_on_cran()
   # with topic argument
-  expect_error(ntfy_send("Basic test message", topic = TEST_TOPIC), regex = "HTTP 403 Forbidden")
-  expect_error(ntfy_send("Basic test message", auth = TRUE, username = "q", password = "z", topic = TEST_TOPIC), regex = "HTTP 401 Unauthorized")
-  expect_error(ntfy_history(topic = TEST_TOPIC), regex = "HTTP 403 Forbidden")
+  expect_error(ntfy_send("Basic test message", topic = TEST_TOPIC), class = "httr2_http_403")
+  expect_error(ntfy_send("Basic test message", auth = TRUE, username = "q", password = "z", topic = TEST_TOPIC), class = "httr2_http_401")
+  expect_error(ntfy_history(topic = TEST_TOPIC), class = "httr2_http_403")
 
   # with env var topic
   Sys.setenv(NTFY_TOPIC = TEST_TOPIC)
-  expect_error(ntfy_send("Basic test message"), regex = "HTTP 403 Forbidden")
-  expect_error(ntfy_send("Basic test message", auth = TRUE, username = "q", password = "z"), regex = "HTTP 401 Unauthorized")
-  expect_error(ntfy_history(), regex = "HTTP 403 Forbidden")
+  expect_error(ntfy_send("Basic test message"), class = "httr2_http_403")
+  expect_error(ntfy_send("Basic test message", auth = TRUE, username = "q", password = "z"), class = "httr2_http_401")
+  expect_error(ntfy_history(), class = "httr2_http_403")
 })
 
 test_that("basic message sending works", {
@@ -120,4 +120,3 @@ test_that("done and friends work", {
       ntfy_done_with_timing(auth = TRUE)
   })
 })
-

--- a/tests/testthat/test-public_server.R
+++ b/tests/testthat/test-public_server.R
@@ -22,7 +22,7 @@ RANDOM_STRING <- jsonlite::base64url_enc(as.character(Sys.time()))
 
 test_that("auth on public fails", {
   skip_on_cran()
-  expect_error(ntfy_send("this should fail", auth = TRUE), regex = "HTTP 401 Unauthorized")
+  expect_error(ntfy_send("this should fail", auth = TRUE), class = "httr2_http_401")
 })
 
 test_that("basic message sending works", {


### PR DESCRIPTION
This is more accurate than using a regular expression on the test string.