### PR TITLE
Fix image path handling

### DIFF
--- a/R/ntfy.R
+++ b/R/ntfy.R
@@ -85,7 +85,7 @@ ntfy_send <- function(
       ggplot2::ggsave(path, image, width = 5, height = 5)
     } else if (is.character(image)) {
       stopifnot(file.exists(image))
-      filename <- path
+      path <- image
     }
     req <- httr2::req_body_file(req, path)
   }


### PR DESCRIPTION
I keep getting some errors when trying to use `image = "path/to/image"`:

```r
Error in ntfy::ntfy_send(message, title, topic = topic, ...) : 
  object 'path' not found
```

I think this is the source of the problem,  but haven't tested (edited online and) because seeing I can pass ggplot2 objects I'll use that instead. 